### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ http://packages.debian.org/source/colortest-python
 
 Otherwise pip works...
 
-    $ pip install terminal-colors
+    $ python3 -m pip install terminal-colors
 
 Help output:
 ------------


### PR DESCRIPTION
Make the pip install method use python3 -m, because the pip wrapper is deprecated