### PR TITLE
--force-term N, cross-platform command install, depend on windows-curses (only on Windows proper)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+terminal_colors.egg-info/
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Help output:
       -v, --vertical       Display with vertical orientation [default].
       -x, --hex            Include hex color numbers on chart.
       -z, --horizontal     Display with horizontal orientation.
+      -m, --force-term=N   Skip termcap color detection and force N colors.
       --version            show program's version number and exit
       -h, --help           show this help message and exit
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 import os
+import sys
 
 def description():
     path = os.path.join(os.path.dirname(__file__), "README.md")
@@ -10,16 +11,20 @@ def description():
             lines.append(line)
         return "".join(lines).strip()
 
-setup(name='terminal-colors',
-	version='3.0.0',
-	description='Utility to test color capabilities of terminal.',
-	long_description=description(),
-	author='John Eikenberry',
-	author_email='jae@zhar.net',
+install_requires = [
+    "windows-curses ; platform_system=='Windows'",
+]
+
+setup(
+    name='terminal-colors',
+    version='3.0.3',
+    description='Utility to test color capabilities of terminal.',
+    long_description=description(),
+    author='John Eikenberry',
+    author_email='jae@zhar.net',
     url="https://github.com/eikenb/terminal-colors",
-    scripts=['terminal-colors'],
-    packages=find_packages(),
-	classifiers=[
+    packages=["terminal_colors"],
+    classifiers=[
         'Development Status :: 6 - Mature',
         'Intended Audience :: End Users/Desktop',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
@@ -29,4 +34,6 @@ setup(name='terminal-colors',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ],
+    install_requires=install_requires,
+    entry_points={'console_scripts': ['terminal-colors = terminal_colors.terminal_colors:main']},
 )


### PR DESCRIPTION
* added `--force-term N` to test for color support outside of what `tigetnum('colors')` reports

* added cross-platform `terminal-colors` cli command installation [per PyPA conventions](https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts)

  On Windows this creates a `terminal-colors.exe` shim. Also tested this method works on Ubuntu.
* declared platform-specific dependency on `windows-curses`

Sorry I was working off of the source code from a pip install and didn't see your most recent repo commits regarding removing the `tigetnum('colors')` check-or-fail. All these changes I made without knowing you had made yours. But I think they're still useful, and maybe with `--force-term N` it might make sense to keep the failure check in, since that might encourage the Windows Terminal folks or the windows-curses folks to improve termcap reporting some day.

As far as I could figure out, in order to use the PyPA console_scripts shimgen, the script had to be addressable as a module, so I ended up moving it to a module dir and changing the hyphen to and underscore, and added the `.py` extension to make it importable. Unfortunately this makes the project feel less Unix-y and more Python-y -- all just to make it easier for Windows users to be able to run `terminal-colors` like any other PIP-installable command line tool. Whether you want to adopt this structural change, I really don't know. If downstream folks are really only interested in the standalone Python script, it seems trivial to export it and rename it. Maybe provide a script to automate that, I don't know.

Also, in Python 3.12, the setuptools module is no longer shipped with Python (to encourage people away from `setup.py`). We should probably switch to `pyproject.toml` eventually.